### PR TITLE
RSS and Atom Feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,12 +5,8 @@ title = "ACM UMN"
 compile_sass = true
 build_search_index = false
 
+generate_feeds = true
+feed_filenames = ["rss.xml", "atom.xml"]
 
 [markdown]
 highlight_code = true
-
-[slugify]
-paths = "on"
-anchors = "on"
-
-[extra]


### PR DESCRIPTION
This enables RSS and Atom feeds for the newsletter and site.

This also cleans up the config.toml, removing unneeded or default settings.