### PR TITLE
Port Newsletter from Mailchimp

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,4 +9,4 @@ generate_feeds = true
 feed_filenames = ["rss.xml", "atom.xml"]
 
 [markdown]
-highlight_code = true
+highlight_code = false

--- a/content/newsletter/2024-01-29-newsletter.md
+++ b/content/newsletter/2024-01-29-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 3: Look at the Trees!"
 template = "post.html"
 
-description = ""
+description = "Unix class 2 coming up! Make sure to RSVP."
 slug = "look-at-the-trees"
 
 date = 2024-01-29

--- a/content/newsletter/2024-01-29-newsletter.md
+++ b/content/newsletter/2024-01-29-newsletter.md
@@ -1,0 +1,31 @@
++++
+title = "Week 3: Look at the Trees!"
+template = "post.html"
+
+description = ""
+slug = "look-at-the-trees"
+
+date = 2024-01-29
+
+authors = ["ACM UMN Officers"]
++++
+Hello everyone!! Let's get that semester rhythm going! The weather is unusually moderate, and it's a good time to look at trees, which brings us to...
+
+## Unix Class 2
+
+Our second main event for Spring '24, we'll be hosting our Unix Classes! This week will be dive into Git, a powerful source-code management system that ensures you never lose a project ever again! Unix Class 2 will be at Keller 3-210 on this Thursday (02/01) from 5:30PM - 6:30PM! RSVP NOW using [this link](@/rsvp.md)
+
+Unix Classes will run weekly for three more weeks every Thursday from 5:30PM - 6:30PM! RSVP for all events at the link above!
+
+# Open House
+
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!
+
+The door lock on Keller 2-204 does not work right now (>_<), but we anticipate the door lock working for Open House. If it does, drop by for a quick celebration! If not, we'll let you know on our Discord:
+
+----------
+
+Visit us at [https://acm.umn.edu/](/) or join our Discord server at [https://z.umn.edu/acm-discord](@/discord.md)!
+
+Lots of love,
+The ACM Officers

--- a/content/newsletter/2024-03-12-newsletter.md
+++ b/content/newsletter/2024-03-12-newsletter.md
@@ -1,0 +1,39 @@
++++
+title = "Week 9"
+template = "post.html"
+
+description = ""
+slug = "2024-w9"
+
+date = 2024-03-12
+
+authors = ["ACM UMN Officers"]
++++
+Hello everyone!! Time is quite the whirlwind, huh? I've forgotten way too many Weekly Newsletters to count, but I remembered right in time for one of ACM's big events this semester!
+
+# Capture the Flag
+
+One of our big events this semester, Capture the Flag is a grand tour and test of your cybersecurity skills and knowledge!
+
+The objective: find hidden strings (known as "flags") within literally anything we're throwing at you - from web servers and applications to photo files and potentially even more.
+
+The techniques: anything and everything a cool person would use, from reading object dumps and understanding code to sleuthing and appreciating art on the internet!
+
+Capture the Flag is a beginner-friendly event, so feel free to show up no matter what you feel your skill level is! We'll be here to show off the techniques commonly found in CTF challenges, and some of the flags can be extracted in very unexpected ways!
+
+Capture the Flag kicks off at Keller Hall 3-111 on Thursday March 14 at 6:00PM-8:00PM! Don't worry if you can't come in-person, though! The CTF server runs for 24 hours after the kickoff - and you'll have the chance to compete remotely at [https://ctf.acm.umn.edu/](https://ctf.acm.umn.edu/)
+
+# Microhack update
+
+Thanks to everyone who showed interest in Microhack, we have good news! The hacking period for Microhack will be held from 6pm Friday, March 22 to 6pm Sunday, March 24. We'll be starting with an (optional) kickoff event in Keller 3-230 at 5:30pm on March 22, so mark your calendars! If you are interested, please join the Microhack discord server. All further information will be communicated in this server, including the link to the Devpost and more updates as the event gets closer. Hope to see you all at kickoff!
+
+# Open House
+
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!he door lock on Keller 2-204 does not work right now (>_<), but we anticipate the door lock working for Open House. If it does, drop by for a quick celebration! If not, we'll let you know on our Discord:
+
+----------
+
+Visit us at [https://acm.umn.edu/](/) or join our Discord server at [https://z.umn.edu/acm-discord](@/discord.md)!
+
+Lots of love,
+The ACM Officers

--- a/content/newsletter/2024-03-12-newsletter.md
+++ b/content/newsletter/2024-03-12-newsletter.md
@@ -29,7 +29,7 @@ Thanks to everyone who showed interest in Microhack, we have good news! The hack
 
 # Open House
 
-Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!he door lock on Keller 2-204 does not work right now (>_<), but we anticipate the door lock working for Open House. If it does, drop by for a quick celebration! If not, we'll let you know on our Discord:
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!he door lock on Keller 2-204 does not work right now (>_<), but we anticipate the door lock working for Open House. If it does, drop by for a quick celebration! If not, we'll let you know on our Discord
 
 ----------
 

--- a/content/newsletter/2024-03-12-newsletter.md
+++ b/content/newsletter/2024-03-12-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 9"
 template = "post.html"
 
-description = ""
+description = "Capture the Flag 2024, MicroHack."
 slug = "2024-w9"
 
 date = 2024-03-12

--- a/content/newsletter/2024-03-18-newsletter.md
+++ b/content/newsletter/2024-03-18-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 10: It's actually Week 10????"
 template = "post.html"
 
-description = ""
+description = "Come by the room on Thursday for Presentation Night."
 slug = "2024-w10"
 
 date = 2024-03-18

--- a/content/newsletter/2024-03-18-newsletter.md
+++ b/content/newsletter/2024-03-18-newsletter.md
@@ -1,0 +1,35 @@
++++
+title = "Week 10: It's actually Week 10????"
+template = "post.html"
+
+description = ""
+slug = "2024-w10"
+
+date = 2024-03-18
+
+authors = ["ACM UMN Officers"]
++++
+Hello everyone!! I finally figured out that it's Week 10. What the heck?
+
+## Presentation Night
+
+ACM will be hosting a Presentation Night this Thursday, March 21 at Keller 3-111 from 6:00PM-8:00PM!
+
+If you've ever wanted to talk to a captive audience about your favorite little hyperfixation, a weird programming language, or a cool project you've done, this is the time! We are looking for speakers! DM Autumn (auctumnus) or RIley (zackerthescar) on Discord to save a spot for Presentation Night!
+
+Don't wanna present but still want to show up and listen? That cool too! Everyone is welcome! RSVP for Presentation Night with [this link](@/rsvp.md).
+
+## Microhack update
+
+Thanks to everyone who showed interest in Microhack, we have good news! The hacking period for Microhack will be held from 6pm Friday, March 22 to 6pm Sunday, March 24. We'll be starting with an (optional) kickoff event in Keller 3-230 at 5:30pm on March 22, so mark your calendars! If you are interested, please join the Microhack discord server. All further information will be communicated in this server, including the link to the Devpost and more updates as the event gets closer. Hope to see you all at kickoff!
+
+## Open House
+
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!
+
+----------
+
+Visit us at [https://acm.umn.edu/](/) or join our Discord server at [https://z.umn.edu/acm-discord](@/discord.md)!
+
+Lots of love,
+The ACM Officers

--- a/content/newsletter/2024-04-08-newsletter.md
+++ b/content/newsletter/2024-04-08-newsletter.md
@@ -1,0 +1,38 @@
++++
+title = "Week 13: Simple and Clean"
+template = "post.html"
+
+description = ""
+slug = "2024-w13"
+
+date = 2024-04-08
+
+authors = ["ACM UMN Officers"]
++++
+T - 2 weeks, gearing up for finals, and we have some exciting stuff in this letter, so pay attention!
+
+Paper Pals
+
+ACM will be hosting Paper Pals next week on Wednesday (4/10) from 6:00PM-7:00PM at Akerman Hall 327! This is the event where we collectively read a paper and discuss it together as a club! We'll be reading and discussing Multi-Touch Querying on Data Physicalizations in Immersive AR by Herman et. al, which you can find at https://dl.acm.org/doi/abs/10.1145/3488542
+
+We do recommend reading the paper ahead of time, but feel free to attend even without having read the paper! RSVP for Paper Pals now at https://acm.umn.edu/rsvp!
+
+Open House
+
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!
+
+Election Season
+
+With the end of the school year comes time for the 2024-2025 ACM Officership Election, but first we need nominations for candidacy. To be eligible for candidacy, you must:
+
+    Be a current member of ACM UMN
+    Have two nominations from other current ACM UMN members
+
+If you meet these requirements and would like to pursue a leadership role at ACM UMN, sign up for candidacy here: https://docs.google.com/forms/d/e/1FAIpQLSeZ_r0D655UFzsJR8VbZmrR7VXNTtA6FMaXjWtpLxDqvMj5Vg/viewform
+
+-----------
+
+Visit us at [https://acm.umn.edu/](/) or join our Discord server at [https://z.umn.edu/acm-discord](@/discord.md)!
+
+Lots of love,
+The ACM Officers

--- a/content/newsletter/2024-04-08-newsletter.md
+++ b/content/newsletter/2024-04-08-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 13: Simple and Clean"
 template = "post.html"
 
-description = ""
+description = "Paper Pals paper discussion club and internal elections."
 slug = "2024-w13"
 
 date = 2024-04-08
@@ -11,17 +11,17 @@ authors = ["ACM UMN Officers"]
 +++
 T - 2 weeks, gearing up for finals, and we have some exciting stuff in this letter, so pay attention!
 
-Paper Pals
+## Paper Pals
 
 ACM will be hosting Paper Pals next week on Wednesday (4/10) from 6:00PM-7:00PM at Akerman Hall 327! This is the event where we collectively read a paper and discuss it together as a club! We'll be reading and discussing Multi-Touch Querying on Data Physicalizations in Immersive AR by Herman et. al, which you can find at https://dl.acm.org/doi/abs/10.1145/3488542
 
 We do recommend reading the paper ahead of time, but feel free to attend even without having read the paper! RSVP for Paper Pals now at https://acm.umn.edu/rsvp!
 
-Open House
+## Open House
 
 Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!
 
-Election Season
+## Election Season
 
 With the end of the school year comes time for the 2024-2025 ACM Officership Election, but first we need nominations for candidacy. To be eligible for candidacy, you must:
 

--- a/content/newsletter/2024-04-16-newsletter.md
+++ b/content/newsletter/2024-04-16-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 14: Tax Day"
 template = "post.html"
 
-description = ""
+description = "Cast your ballot in the ACM UMN Officership Election."
 slug = "2024-w14"
 
 date = 2024-04-16

--- a/content/newsletter/2024-04-16-newsletter.md
+++ b/content/newsletter/2024-04-16-newsletter.md
@@ -1,0 +1,29 @@
++++
+title = "Week 14: Tax Day"
+template = "post.html"
+
+description = ""
+slug = "2024-w14"
+
+date = 2024-04-16
+
+authors = ["ACM UMN Officers"]
++++
+Seems like my 1040 occupied all of yesterday and I forgot to send out this mailing list update!
+
+## Open House
+
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!
+
+## Election Season
+
+With the end of the school year comes time for the 2024-2025 ACM Officership Election. Do your part in determining the future of our club! If you're an ACM member, click on the link below to find your ballot!
+
+https://forms.gle/jGBbga6oYXGz5ZQx5
+
+----------
+
+Visit us at [https://acm.umn.edu/](/) or join our Discord server at [https://z.umn.edu/acm-discord](@/discord.md)!
+
+Lots of love,
+The ACM Officers

--- a/content/newsletter/2024-04-22-newsletter.md
+++ b/content/newsletter/2024-04-22-newsletter.md
@@ -1,0 +1,37 @@
++++
+title = "Week 15: Finals..."
+template = "post.html"
+
+description = ""
+slug = "2024-w15"
+
+date = 2024-04-22
+
+authors = ["Quinn"]
++++
+Soon we'll all be in finalmode... (Some of us already are...)
+
+## Election Results
+
+Thank you to everyone who voted in the 2024-2025 ACM Officer Elections! Here are our results!
+
+President: Iris Gorton
+Vice President: Autumn Kenyon
+Treasurer: Alice Janik
+Systems Administrator: Nadia Potteiger
+Webmaster: Riley Loo
+Membership: Elena Nelson
+Secretary: Quinn Korsune
+
+We (the 2024-2025 ACM Officers) are looking forward to see you in the 2024-2025 academic year!
+
+## Open House
+
+Our Open House for this semester will be every Wednesday 4:00PM - 6:00PM! Come hang out with us at the ACM Club Room at Keller 2-204! Come hang, introduce yourself, lounge and chill. We promise we don't bite!
+
+----------
+
+Visit us at [https://acm.umn.edu/](/) or join our Discord server at [https://z.umn.edu/acm-discord](@/discord.md)!
+
+Lots of love,
+The ACM Officers

--- a/content/newsletter/2024-04-22-newsletter.md
+++ b/content/newsletter/2024-04-22-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 15: Finals..."
 template = "post.html"
 
-description = ""
+description = "The new ACM Officers and getting into finalmode."
 slug = "2024-w15"
 
 date = 2024-04-22
@@ -15,13 +15,13 @@ Soon we'll all be in finalmode... (Some of us already are...)
 
 Thank you to everyone who voted in the 2024-2025 ACM Officer Elections! Here are our results!
 
-President: Iris Gorton
-Vice President: Autumn Kenyon
-Treasurer: Alice Janik
-Systems Administrator: Nadia Potteiger
-Webmaster: Riley Loo
-Membership: Elena Nelson
-Secretary: Quinn Korsune
+- President: Iris Gorton
+- Vice President: Autumn Kenyon
+- Treasurer: Alice Janik
+- Systems Administrator: Nadia Potteiger
+- Webmaster: Riley Loo
+- Membership: Elena Nelson
+- Secretary: Quinn Korsune
 
 We (the 2024-2025 ACM Officers) are looking forward to see you in the 2024-2025 academic year!
 

--- a/content/newsletter/2024-09-04-newsletter.md
+++ b/content/newsletter/2024-09-04-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 1: Initiating Fall 2024"
 template = "post.html"
 
-description = ""
+description = "Welcome to a new year of ACM UMN!"
 slug = "2024-f-w1"
 
 date = 2024-09-04

--- a/content/newsletter/2024-09-04-newsletter.md
+++ b/content/newsletter/2024-09-04-newsletter.md
@@ -1,0 +1,36 @@
++++
+title = "ACM Week 1: Initiating Fall 2024"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w1"
+
+date = 2024-09-04
+
+authors = ["ACM UMN Officers"]
++++
+Hi ACM,
+
+Welcome to the new school year and another exciting year of ACM! You likely have lots to do — us too. So quickly,
+
+## About ACM
+
+For those who are new, we will be running two nights of About ACM, first on Thursday, Sept. 5 and then on Wednesday, Sept. 11, both at 5pm in Keller Hall Room 2-204. We’ll show you around the clubroom, let you know what we do and how you can get involved, and more. It’s a casual event (as all our events are), we only ask that you if you plan on attending you RSVP for your preferred day at acm.umn.edu/rsvp.
+
+## Open House (But Not This Week!)
+
+Open houses for this semester will be every Wednesday 4-6pm, except for this week. During this time, we welcome you to hang with us in the ACM room, talk to us and each other, just soak up the space, whatever you’d like. This week tho, find us at Fall Tech Kickoff on Wednedsay.
+
+## Fall Tech Kickoff (Tonight!)
+
+ACM plus many other tech clubs at UMN will be at Fall Tech Kickoff (Sept. 4 at 5-7pm, HSEC Room 3-110). Say hi to us and get to know the larger community. It’s fun to get involved with different scenes, network between them, etc.
+
+## UNIX Classes
+
+Before you know it, we will be hosting our popular UNIX classes. Look forward to the first one on 9/17, and stay tuned for more info.
+
+Shout out to newheads and oldheads alike and thank you everyone for being here. :)
+
+See you soon,
+
+Quinn

--- a/content/newsletter/2024-09-10-newsletter.md
+++ b/content/newsletter/2024-09-10-newsletter.md
@@ -2,7 +2,7 @@
 title = "Week 2: UNIX Class"
 template = "post.html"
 
-description = ""
+description = "Amundson B75, Sept 17, 5:30."
 slug = "2024-f-w2"
 
 date = 2024-09-10

--- a/content/newsletter/2024-09-10-newsletter.md
+++ b/content/newsletter/2024-09-10-newsletter.md
@@ -1,0 +1,26 @@
++++
+title = "Week 2: UNIX Class"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w2"
+
+date = 2024-09-10
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+Week 2 and we're already going strong. Notable announcements for this week:
+
+Our About ACM dates were moved to Tuesday, Sept. 10 (tonight!) and Thursday, Sept. 12, still at 5pm in Keller 2-204 for each. If you're new, we'd love to see you at one of the two days, just try to RSVP if you plan on attending. (And join the Discord to keep up with events and schedule changes like these in real time.)
+
+We'll also be hosting our first Open House of the year this Wednesday at 5pm, so come hang with us in the ACM room (Keller 2-204), or use this as an opportunity to get a sampling of the club if you can't make it to About ACM.
+
+UNIX Classes are getting started next week (Sept. 17, 5:30pm in Amundson B75)! These are a good way to learn essential skills that you will need for your classes and beyond, beginning with shell basics for the first class. RSVP for free pizza!
+
+That should do it. It's been nice seeing familiar faces as well as new ones in the ACM room. Come say hi if you haven't yet, the more the merrier.
+
+Have a nice week,
+
+Quinn

--- a/content/newsletter/2024-09-16-newsletter.md
+++ b/content/newsletter/2024-09-16-newsletter.md
@@ -1,0 +1,26 @@
++++
+title = "ACM Week 3: UNIX Classes Begin Tuesday"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w3"
+
+date = 2024-09-16
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+
+Week 3 now. Things are happening. Take a look:
+
+UNIX Classes start this Tuesday (Sept. 17, 5:30pm in Amundson B75)! Join us to learn about Shell Basics. Beginners absolutely welcome. RSVP for free pizza, and use the same form to RSVP for next week's lesson #2 on Git while you're at it.
+
+Also remember Open House is every Wednesday 4-6pm in Keller 2-204 (the ACM room!). Hang out, chat, study, etc. New people are always welcome too — it's never too late to get acquainted.
+
+Hope classes are going well and you're finding your pacing. The ACM room is a good place to chill/study between classes if the door is open (or if you have door access; come to three events → become a member).
+
+
+:),
+
+Quinn

--- a/content/newsletter/2024-09-16-newsletter.md
+++ b/content/newsletter/2024-09-16-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 3: UNIX Classes Begin Tuesday"
 template = "post.html"
 
-description = ""
+description = "Remember to come to open house Wed 4-6pm."
 slug = "2024-f-w3"
 
 date = 2024-09-16

--- a/content/newsletter/2024-09-23-newsletter.md
+++ b/content/newsletter/2024-09-23-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 4: UNIX Class 2!"
 template = "post.html"
 
-description = ""
+description = "We are learning Git, and there's free pizza."
 slug = "2024-f-w4"
 
 date = 2024-09-23

--- a/content/newsletter/2024-09-23-newsletter.md
+++ b/content/newsletter/2024-09-23-newsletter.md
@@ -1,0 +1,22 @@
++++
+title = "ACM Week 4: UNIX Class 2!"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w4"
+
+date = 2024-09-23
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+Ah! Week 4:
+
+UNIX Class #2 is on Tuesday (Sept. 24, 5:30pm in Amundson B75). We are learning Git this week! Beginners are more than welcome as always, and it's okay if you missed the first class, you can still attend. RSVP if you plan on coming so we can get you enough free pizza. And feel free to use the same form to RSVP for next week's free pizza where we will be learning about Programming Environments.
+
+Open House Wednesday 4-6pm in Keller 2-204 (ACM room!). It's so fun and awesome.
+
+See you soon,
+
+Quinn

--- a/content/newsletter/2024-09-30-newsletter.md
+++ b/content/newsletter/2024-09-30-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 5: TURBO Telescope Project Opportunity"
 template = "post.html"
 
-description = ""
+description = "Unix class 3 and an opportunity to work on Astrophysics."
 slug = "2024-f-w5"
 
 date = 2024-09-30

--- a/content/newsletter/2024-09-30-newsletter.md
+++ b/content/newsletter/2024-09-30-newsletter.md
@@ -1,0 +1,48 @@
++++
+title = "ACM Week 5: TURBO Telescope Project Opportunity"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w5"
+
+date = 2024-09-30
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+First of all, we have a special opportunity to share with you from Professor Pat Kelly:
+"Dear ACM,
+
+I'm a professor in the Minnesota Institute for Astrophysics, and our team is constructing two sets of robotically operated telescopes on mountains in New Mexico and Greece.
+
+The principal goals are to find supernovae at the time of explosion and light from radioactive material synthesized when neutron stars and black holes merge. We are planning to search the sky after the Laser Interferometer Gravitational-Wave Observatory (LIGO) detects gravitational wave emission from the mergers of these extreme objects.
+
+We are using a modified telescope mount that can slew across the sky in less than two seconds and are trying to assemble a number of
+different components that will independently position two telescopes
+on the mount to cover the area on the sky where the gravitational waves may originate (can be hundreds of square degrees).
+
+Here is a video about the project -- we are running a prototype telescope on the St. Paul campus that we are using for development:
+
+https://twin-cities.umn.edu/news-events/u-m-leading-1-million-grant-build-superfast-turbo-telescopes
+
+A current effort is to develop a software pipeline to process 1.3 Gigapixels of imaging every thirty seconds and identify candidate explosions. We have figured out a way to use the new 4090 GPU's from NVidia to process the images extremely rapidly (<10 seconds), and are now working on several challenges including using machine learning to distinguish between explosions and artifacts in the images. We need a lot of help!
+
+If there are any students with experience with robotics, motor control, or software who might want to join, I would be very interested in working with them or employing them during the school year to work on the project.  Very happy to show students around the lab and the prototype."
+
+
+UNIX Class #3 this Tuesday, Oct. 1, 5:30pm in Amundson B75! This week is about your Programming Environment! Come for free pizza, stay for genuinely useful knowledge that will inevitably be useful for your classes at some point (professors may simply expect you to know this stuff). Remember to RSVP so we get enough pizza. Next week's topic is Dependencies & Nix.
+
+Other Important ACM Notices:
+
+    ACM is closed for rest of day today (Monday 9/30) for carpet cleaning.
+    If you want to get ACM member benefits (clubroom door access, free server/VM, extra discord channels), you must:
+        Come and sign in to 3 events.
+        Fill out member form (acm.umn.edu/member).
+        Notify an officer that you completed the form.
+
+Come to Open House Wednesday 4-6pm in Keller 2-204 (ACM room).
+
+See you and good luck,
+
+Quinn

--- a/content/newsletter/2024-10-07-newsletter.md
+++ b/content/newsletter/2024-10-07-newsletter.md
@@ -1,0 +1,20 @@
++++
+title = "ACM Week 6: (U)NIX Class "
+template = "post.html"
+
+description = ""
+slug = "2024-f-w6"
+
+date = 2024-10-07
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+Just like that, it's the last week of UNIX Class! Join us on Tuesday, Oct. 8 at 5:30pm in Amundson B75 to learn about Dependencies and Nix! If you have not yet attended your 3 events to qualify for ACM membership benefits, this is a good way to do it. RSVP [here](@/rsvp.md).
+
+Open House is Wednesday 4-6pm in the ACM Room (Keller 2-204) as always. This can also count towards your 3 events for membership, plus it's a good way to meet people and hang out.
+
+Computerly,
+
+Quinn

--- a/content/newsletter/2024-10-07-newsletter.md
+++ b/content/newsletter/2024-10-07-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 6: (U)NIX Class "
 template = "post.html"
 
-description = ""
+description = "Last week of Unix class and the regular."
 slug = "2024-f-w6"
 
 date = 2024-10-07

--- a/content/newsletter/2024-10-14-newsletter.md
+++ b/content/newsletter/2024-10-14-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 7: All Quiet in the Twin Cities"
 template = "post.html"
 
-description = ""
+description = "Self hosting workshop on the horizon."
 slug = "2024-f-w7"
 
 date = 2024-10-14

--- a/content/newsletter/2024-10-14-newsletter.md
+++ b/content/newsletter/2024-10-14-newsletter.md
@@ -1,0 +1,24 @@
++++
+title = "ACM Week 7: All Quiet in the Twin Cities"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w7"
+
+date = 2024-10-14
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+It seems like it's week 7. That's good I think. If we took the path of the sun from the beginning of the semester as Portland, Maine to the end of the semester as Portland, Oregon, we'd roughly be in the Twin Cities right now with the time coming 'round near noon o'clock. Lots more daylight still.
+
+With UNIX Classes behind us, the week is fairly quiet ACM-wise. But per usual, catch us at Open House on Wednesday (4-6pm in the ACM Room (Keller 2-204)). Here you will find us doing our weekly group chilling.
+
+On the horizon, Self-Hosting Workshop is next week on Thursday. RSVP now if you're interested: [acm.umn.edu/rsvp](@/rsvp.md). It helps us get you enough free pizza.
+
+I'll see you later.
+
+Truly,
+
+Quinn

--- a/content/newsletter/2024-10-21-newsletter.md
+++ b/content/newsletter/2024-10-21-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 8: Self-Hosting Workshop"
 template = "post.html"
 
-description = ""
+description = "Half way there. Come learn some networking basics at the self hosting workshop."
 slug = "2024-f-w8"
 
 date = 2024-10-21
@@ -18,12 +18,12 @@ Self-Hosting Workshop
 Thursday (10/24) at 5pm
 
 Amundson Hall Room 120
-• Why to self-host
-• Networking basics
-• Containerization
-• Levels of compartmentalizing services
-• Options for if you can't or don't want to self-host at home
-• Some services you might want to use
+- Why to self-host
+- Networking basics
+- Containerization
+- Levels of compartmentalizing services
+- Options for if you can't or don't want to self-host at home
+- Some services you might want to use
 FREE PIZZA → [acm.umn.edu/rsvp](@/rsvp.md)
 
 And chill with us at Open House too. Wednesday 4-6pm in the ACM Room (Keller 2-204). We have fun.

--- a/content/newsletter/2024-10-21-newsletter.md
+++ b/content/newsletter/2024-10-21-newsletter.md
@@ -1,0 +1,33 @@
++++
+title = "ACM Week 8: Self-Hosting Workshop"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w8"
+
+date = 2024-10-21
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+You've met the end of the semester halfway. Good job. Now it's another great week to be all you can be. Join us at:
+
+Self-Hosting Workshop
+
+Thursday (10/24) at 5pm
+
+Amundson Hall Room 120
+• Why to self-host
+• Networking basics
+• Containerization
+• Levels of compartmentalizing services
+• Options for if you can't or don't want to self-host at home
+• Some services you might want to use
+FREE PIZZA → [acm.umn.edu/rsvp](@/rsvp.md)
+
+And chill with us at Open House too. Wednesday 4-6pm in the ACM Room (Keller 2-204). We have fun.
+
+Tessentially,
+
+Quinn

--- a/content/newsletter/2024-10-28-newsletter.md
+++ b/content/newsletter/2024-10-28-newsletter.md
@@ -1,0 +1,27 @@
++++
+title = "ACM Week 9: ACM UMN Special Holiday"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w9"
+
+date = 2024-10-28
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+Week 9. According to online, 9 is a powerful symbol of completion, wisdom, and spiritual growth. It's very interesting.
+
+We don't have a special thing this week, but next week...
+
+Learn how to “hack” in a friendly Capture the Flag (CTF) competition!
+Vulnerable systems ranging from websites to filesystems will be provided and points will be awarded based on your reverse engineering ability. Beginners welcome, we will provide help!
+It's a 24-hour event, but be there for kick-off on Nov. 6 at 7pm in Amundson B75. Free pizza provided 🍕 → acm.umn.edu/rsvp
+
+And remember our weekly Open House, wednesday 4-6pm in the ACM Room (Keller 2-204). This is your chance to enjoy our perpetual halloween decorations during the short window of the year when they are proper by common standards.
+
+
+Yup,
+
+Quinn

--- a/content/newsletter/2024-10-28-newsletter.md
+++ b/content/newsletter/2024-10-28-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 9: ACM UMN Special Holiday"
 template = "post.html"
 
-description = ""
+description = "RSVP for the Capture the Flag competition."
 slug = "2024-f-w9"
 
 date = 2024-10-28
@@ -15,9 +15,10 @@ Week 9. According to online, 9 is a powerful symbol of completion, wisdom, and s
 
 We don't have a special thing this week, but next week...
 
-Learn how to “hack” in a friendly Capture the Flag (CTF) competition!
+## Learn how to “hack” in a friendly Capture the Flag (CTF) competition!
+
 Vulnerable systems ranging from websites to filesystems will be provided and points will be awarded based on your reverse engineering ability. Beginners welcome, we will provide help!
-It's a 24-hour event, but be there for kick-off on Nov. 6 at 7pm in Amundson B75. Free pizza provided 🍕 → acm.umn.edu/rsvp
+It's a 24-hour event, but be there for kick-off on Nov. 6 at 7pm in Amundson B75. Free pizza provided 🍕 → [rsvp](@/rsvp.md)
 
 And remember our weekly Open House, wednesday 4-6pm in the ACM Room (Keller 2-204). This is your chance to enjoy our perpetual halloween decorations during the short window of the year when they are proper by common standards.
 

--- a/content/newsletter/2024-11-04-newsletter.md
+++ b/content/newsletter/2024-11-04-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 10: Capture the Flag (CTF) Event!"
 template = "post.html"
 
-description = ""
+description = "Learn to \"hack\" and reverse engineer with free pizza provided."
 slug = "2024-f-w10"
 
 date = 2024-11-04
@@ -29,15 +29,13 @@ Learn typesetting at Typesetting Workshop!
 - Wednesday, Nov. 13 at 5pm in Amundson 116.
 - Free pizza provided 🍕 (RSVP to our events so we get enough pizza: acm.umn.edu/rsvp)
 
+```
 +
-
 weekly open house
-
 wednesdays 4-6pm
-
 acm room (keller 2-204)
-
 come say hi
+```
 
 
 Like Myshkin from Dostoevsky's The Idiot,

--- a/content/newsletter/2024-11-04-newsletter.md
+++ b/content/newsletter/2024-11-04-newsletter.md
@@ -1,0 +1,45 @@
++++
+title = "ACM Week 10: Capture the Flag (CTF) Event!"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w10"
+
+date = 2024-11-04
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+Good things upcoming:
+
+Learn how to “hack” in a friendly Capture the Flag (CTF) competition!
+- Vulnerable systems ranging from websites to filesystems will be provided for you to hack.
+- Points will be awarded based on your reverse engineering ability.
+- Beginners welcome! (We will provide help!)
+- Join us at kick-off for the 24-hour competition is Wednesday, Nov. 6 at 7pm in Amundson B75.
+- Free pizza provided 🍕 (RSVP to our events so we get enough pizza: acm.umn.edu/rsvp)
+
+And next week:
+
+Learn typesetting at Typesetting Workshop!
+- Want a more professional appearance to your documents?
+- Or an easier way to type math and science papers?
+- Come to the Typesetting Workshop to learn Typst, a new beginner-friendly typesetting software! (And an alternative to LaTeX!)
+- Wednesday, Nov. 13 at 5pm in Amundson 116.
+- Free pizza provided 🍕 (RSVP to our events so we get enough pizza: acm.umn.edu/rsvp)
+
++
+
+weekly open house
+
+wednesdays 4-6pm
+
+acm room (keller 2-204)
+
+come say hi
+
+
+Like Myshkin from Dostoevsky's The Idiot,
+
+Quinn

--- a/content/newsletter/2024-11-11-newsletter.md
+++ b/content/newsletter/2024-11-11-newsletter.md
@@ -1,0 +1,53 @@
++++
+title = "ACM Week 11: Typesetting Workshop with Typst!"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w11"
+
+date = 2024-11-11
+
+authors = ["Quinn"]
++++
+Hi ACMigos. Special events below.
+
+This week...
+
+## Typesetting Workshop with Typst
+- Want a more professional appearance to your documents?
+- Or an easier way to type math and science papers?
+- Join us to learn Typst, a new beginner-friendly typesetting software! (And an alternative to LaTeX!)
+- Wednesday 11/13 at 5pm
+- Amundson Hall Room 116
+- Free pizza 🍕 (RSVP so we get enough pizza: [acm.umn.edu/rsvp](@/rsvp.md))
+
+Next week...
+
+## ACM x Plumb Bob Study Night
+
+As finals begin to approach, we are teaming up with Plumb Bob to offer a nice group study night. Bring your friends!
+- 11/18 (Mon) at 6pm
+- Keller Hall Room 2-260
+- Snacks provided! 🧃
+
+## Drawing Night
+- A night of relaxed drawing with friends old and new!
+- Help fill a big sheet of paper we display in the ACM room every semester.
+- Everyone is welcome, even if you don't know how to draw!
+- 11/19 (Tue) at 5pm
+- Keller Hall Room 2-204
+- RSVP: [acm.umn.edu/rsvp](@/rsvp.md)
+
++
+
+open house
+
+wednesdays 4-6pm
+
+acm room (keller 2-204)
+
+come say hi
+
+Weekly,
+
+Quinn

--- a/content/newsletter/2024-11-11-newsletter.md
+++ b/content/newsletter/2024-11-11-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 11: Typesetting Workshop with Typst!"
 template = "post.html"
 
-description = ""
+description = "Study with Plumb Bob or typset in Typst at our upcoming workshop."
 slug = "2024-f-w11"
 
 date = 2024-11-11
@@ -38,15 +38,13 @@ As finals begin to approach, we are teaming up with Plumb Bob to offer a nice gr
 - Keller Hall Room 2-204
 - RSVP: [acm.umn.edu/rsvp](@/rsvp.md)
 
+```
 +
-
 open house
-
 wednesdays 4-6pm
-
 acm room (keller 2-204)
-
 come say hi
+```
 
 Weekly,
 

--- a/content/newsletter/2024-11-17-newsletter.md
+++ b/content/newsletter/2024-11-17-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 12 • Study Night + Drawing Night"
 template = "post.html"
 
-description = ""
+description = "Come chat with friends and draw on a big sheet of paper at drawing night."
 slug = "2024-f-w12"
 
 date = 2024-11-17
@@ -27,16 +27,13 @@ If you're reading this you've made it to week 12. As a reward, help yourself to 
 - Tuesday 11/19 at 5pm
 - Keller 2-204
 
+```
 +
-
 open house
-
 wednesdays 4-6pm
-
 acm room (keller 2-204)
-
 come say hi
-
+```
 
 
 Of course,

--- a/content/newsletter/2024-11-17-newsletter.md
+++ b/content/newsletter/2024-11-17-newsletter.md
@@ -1,0 +1,44 @@
++++
+title = "ACM Week 12 • Study Night + Drawing Night"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w12"
+
+date = 2024-11-17
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+If you're reading this you've made it to week 12. As a reward, help yourself to the following events...
+
+## Study Night
+- ACM and Plumb Bob are teaming up to offer a fun, relaxing study night for CSE students and friends!
+- Monday 11/18 at 6pm
+- Keller 2-260
+- Snacks provided!
+
+
+## Drawing Night
+- A nice evening of drawing with friends old and new!
+- Help fill our fresh big sheet of paper that we'll display in the ACM room for the next semester!
+- Everyone is welcome, no need to be "good" at drawing!
+- Tuesday 11/19 at 5pm
+- Keller 2-204
+
++
+
+open house
+
+wednesdays 4-6pm
+
+acm room (keller 2-204)
+
+come say hi
+
+
+
+Of course,
+
+Quinn

--- a/content/newsletter/2024-11-25-newsletter.md
+++ b/content/newsletter/2024-11-25-newsletter.md
@@ -1,0 +1,38 @@
++++
+title = "ACM Week 13 • Prepare for Presentation Night!"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w13"
+
+date = 2024-11-25
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+As you know, it's a week of reprieve. We hope you find yourself with good thanks and graces.
+
+But on the Tuesday right after the break, ACM will be hosting...
+
+## Presentation Night!
+- Come talk to us about your favorite obscure programming language, tell a really elaborate joke, or anything else you want to present to people about!
+- Or simply enjoy watching others' presentations while treating yourself to free pizza! 🍕
+- Dec. 3 at 5pm in Amundson 120
+- Please RSVP so we get enough pizza → [acm.umn.edu/rsvp](@/rsvp.md)
+
++
+
+Open House
+
+Wednesdays 4-6pm
+
+ACM Room (Keller 2-204)
+
+Come say hi
+
+
+
+Thankfully,
+
+Quinn

--- a/content/newsletter/2024-11-25-newsletter.md
+++ b/content/newsletter/2024-11-25-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 13 • Prepare for Presentation Night!"
 template = "post.html"
 
-description = ""
+description = "December 3rd at 5pm, Amundson 120."
 slug = "2024-f-w13"
 
 date = 2024-11-25
@@ -21,15 +21,13 @@ But on the Tuesday right after the break, ACM will be hosting...
 - Dec. 3 at 5pm in Amundson 120
 - Please RSVP so we get enough pizza → [acm.umn.edu/rsvp](@/rsvp.md)
 
+```
 +
-
 Open House
-
 Wednesdays 4-6pm
-
 ACM Room (Keller 2-204)
-
 Come say hi
+```
 
 
 

--- a/content/newsletter/2024-12-02-newsletter.md
+++ b/content/newsletter/2024-12-02-newsletter.md
@@ -2,7 +2,7 @@
 title = "ACM Week 14 • Presentation Night!"
 template = "post.html"
 
-description = ""
+description = "Tell us about an obscure programming language or tell a really elaborate joke! Dec 3, 5pm, Amundson 120."
 slug = "2024-f-w14"
 
 date = 2024-12-02
@@ -23,15 +23,13 @@ Good job on thanksgiving! Now get ready because this week we are hosting our las
 // (and let an officer know if you plan to present)
 ```
 
+```
 +
-
 Open House
-
 Wednesdays 4-6pm
-
 ACM Room (Keller 2-204)
-
 Come say hi
+```
 
 
 

--- a/content/newsletter/2024-12-02-newsletter.md
+++ b/content/newsletter/2024-12-02-newsletter.md
@@ -1,0 +1,40 @@
++++
+title = "ACM Week 14 • Presentation Night!"
+template = "post.html"
+
+description = ""
+slug = "2024-f-w14"
+
+date = 2024-12-02
+
+authors = ["Quinn"]
++++
+
+Hi ACM,
+
+Good job on thanksgiving! Now get ready because this week we are hosting our last event of the semester:
+
+## Presentation Night!
+- Come talk to us about your favorite obscure programming language, tell a really elaborate joke, or anything else you want to present to people about!
+- Or simply enjoy watching others' presentations while treating yourself to free pizza! 🍕
+```
+// Dec. 3 at 5pm in Amundson 120
+// Please RSVP so we get enough pizza → acm.umn.edu/rsvp
+// (and let an officer know if you plan to present)
+```
+
++
+
+Open House
+
+Wednesdays 4-6pm
+
+ACM Room (Keller 2-204)
+
+Come say hi
+
+
+
+In good faith,
+
+Quinn

--- a/content/newsletter/2025-01-21-newsletter.md
+++ b/content/newsletter/2025-01-21-newsletter.md
@@ -1,0 +1,34 @@
++++
+title = "ACM S25 Week 1"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w1"
+
+date = 2024-01-21
+
+authors = ["Quinn"]
++++
+Good morning ACM,
+
+Yay! Updates on the new semester below, including information on MinneHack, our biggest event of the year!
+
+## UNIX Classes!
+
+Need to learn more about the Linux command line for your classes? UNIX Classes cover all of that and more! Learn about basic terminal use, Git, how to set up your programming environment, and more!
+- First class (Shell Basics) at 5pm Jan. 30 in Smith Hall 331
+- RSVP so we get enough pizza for you! → [acm.umn.edu/rsvp](@/rsvp.md)
+
+## MinneHack!
+
+MinneHack is the biggest hackathon in Minnesota and welcomes hackers from around the country! Join us for this 24-hour event where you can create, collaborate, and compete to make something amazing! We give out thousands of dollars in prizes!
+- Check-in starts at noon on Saturday, Feb. 8
+- Register here: registration.minnehack.io
+
+Our Open House time is still Wednesdays 4-6pm! Visit us in the ACM room (Keller 2-204) during this time to chat, do homework, or whatever you want. :)
+
+
+
+Best,
+
+Quinn

--- a/content/newsletter/2025-01-21-newsletter.md
+++ b/content/newsletter/2025-01-21-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 1"
 template = "post.html"
 
-description = ""
+description = "Looking forward to MinneHack, the biggest hackathon in Minnesota."
 slug = "2025-s-w1"
 
-date = 2024-01-21
+date = 2025-01-21
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-01-27-newsletter.md
+++ b/content/newsletter/2025-01-27-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 2"
 template = "post.html"
 
-description = ""
+description = "RSVP for Unix class. The first workshop will cover the basics of using the shell."
 slug = "2025-s-w2"
 
-date = 2024-01-27
+date = 2025-01-27
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-01-27-newsletter.md
+++ b/content/newsletter/2025-01-27-newsletter.md
@@ -1,0 +1,35 @@
++++
+title = "ACM S25 Week 2"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w2"
+
+date = 2024-01-27
+
+authors = ["Quinn"]
++++
+Hello again ACM,
+
+Another week one done, good job! Here's what is coming up in ACM:
+
+## UNIX Classes (starting this thursday!)
+Need to learn more about the Linux command line for your classes? UNIX Classes cover all of that and more! Learn about basic terminal use, Git, how to set up your programming environment, and more!
+- First class (Shell Basics) at 5pm Jan. 30 in Smith Hall 331
+- RSVP so we get enough pizza for you! → [acm.umn.edu/rsvp](@/rsvp.md)
+
+## MinneHack!
+MinneHack, the biggest hackathon in Minnesota, welcomes hackers from around the country for a 24-hour event where you can create, collaborate, and compete to make something amazing! We give out thousands of dollars in prizes! For more information, see minnehack.io.
+- Check-in starts at noon Saturday, Feb. 8 at the Coffman Great Hall
+- Register for free here: registration.minnehack.io
+
+```
+ACM Open House
+Wednesdays 4-6pm
+ACM Room (Keller 2-204)
+Come say hi!
+```
+
+Wishing you well,
+
+Quinn

--- a/content/newsletter/2025-02-03-newsletter.md
+++ b/content/newsletter/2025-02-03-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 3"
 template = "post.html"
 
-description = ""
+description = "All hands on deck. It's MinneHack time."
 slug = "2025-s-w3"
 
-date = 2024-02-03
+date = 2025-02-03
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-02-03-newsletter.md
+++ b/content/newsletter/2025-02-03-newsletter.md
@@ -1,0 +1,31 @@
++++
+title = "ACM S25 Week 3"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w3"
+
+date = 2024-02-03
+
+authors = ["Quinn"]
++++
+## ACM! It's MinneHack time!
+
+Register for free [here](https://www.minnehack.com/) so you can join us to create, collaborate, and compete to make something amazing in Minnesota's largest hackathon! Thousands of dollars in prizes! More info at minnehack.io.
+- This Saturday (check-in at noon) to Sunday (Feb 8-9)
+- Coffman Great Hall
+
+And UNIX Class #2 is this Thursday! This week we will be covering Git!
+- Feb 6 at 5pm in Smith Hall 331
+- RSVP to ensure your free pizza! → acm.umn.edu/rsvp
+
+```
+ACM Open House
+Wednesdays 4-6pm
+ACM Room (Keller 2-204)
+Come say hi!
+```
+
+See you soon!
+
+Quinn

--- a/content/newsletter/2025-02-18-newsletter.md
+++ b/content/newsletter/2025-02-18-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 5 "
 template = "post.html"
 
-description = ""
+description = "Unix class 3 is on Programming Environments. Pizza will be in attendance."
 slug = "2025-s-w5"
 
-date = 2024-02-18
+date = 2025-02-18
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-02-18-newsletter.md
+++ b/content/newsletter/2025-02-18-newsletter.md
@@ -1,0 +1,34 @@
++++
+title = "ACM S25 Week 5 "
+template = "post.html"
+
+description = ""
+slug = "2025-s-w5"
+
+date = 2024-02-18
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+It's been a bit since we checked in email-wise but thank you and congratulations to everyone who participated in MinneHack a couple weeks ago! With your help it was a great success and we loved seeing your projects!
+
+In terms of this week:
+
+UNIX Class #3 is this Thursday! Come to learn about Programming Environments (and stay for the free pizza).
+- Feb 20 at 5pm in Smith Hall 331
+- RSVP so we get enough pizza for you 🍕 → [acm.umn.edu/rsvp](@/rsvp.md)
+(+ Feel free to RSVP for next week's class — the last one — on Dependencies and Nix while you're at it.)
+
+And of course,
+
+```
+ACM Open House
+Wednesdays 4-6pm
+ACM Room (Keller 2-204)
+Come say hi!
+```
+
+Very respectfully,
+
+Quinn

--- a/content/newsletter/2025-03-04-newsletter.md
+++ b/content/newsletter/2025-03-04-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 7"
 template = "post.html"
 
-description = ""
+description = "Join us in Keller for Drawing Night."
 slug = "2025-s-w7"
 
-date = 2024-03-04
+date = 2025-03-04
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-03-04-newsletter.md
+++ b/content/newsletter/2025-03-04-newsletter.md
@@ -1,0 +1,20 @@
++++
+title = "ACM S25 Week 7"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w7"
+
+date = 2024-03-04
+
+authors = ["Quinn"]
++++
+Hey ACM,
+
+Drawing night is this week (tomorrow — wednesday 3/4 at 4pm), join us in the ACM room (Keller 2-204) to help renew our semesterly canvas that we display in there! We get lots of different styles from every skill level, we encourage everyone to contribute.
+
+Also, this will take place at the same place and time as our usual open house, so you may go to that as well, we will just be using a part of the room to draw.
+
+Happy birthdays,
+
+Quinn

--- a/content/newsletter/2025-03-17-newsletter.md
+++ b/content/newsletter/2025-03-17-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 9"
 template = "post.html"
 
-description = ""
+description = "Blog Workshop next thursday. We will be building some simple blogs using the Zola framework."
 slug = "2025-s-w9"
 
-date = 2024-03-17
+date = 2025-03-17
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-03-17-newsletter.md
+++ b/content/newsletter/2025-03-17-newsletter.md
@@ -1,0 +1,32 @@
++++
+title = "ACM S25 Week 9"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w9"
+
+date = 2024-03-17
+
+authors = ["Quinn"]
++++
+Hey ACM,
+
+What might ACM have coming up?? (↓↓↓↓)
+
+Looking for some friendly programming competition? Join us for Code Golf this Thursday and attempt to solve a set of small computing problems in the smallest amount of code!
+- March 20 @ 5:30pm
+- Keller 3-111
+- RSVP for free pizza: [acm.umn.edu/rsvp](@/rsvp.md)
+
+Also, get ready for Blog Workshop next week Thursday! We will cover some basic web development and how to build your own blog using the Zola framework.
+- March 27 @ 5pm
+- Keller 3-111
+- RSVP for free pizza: [acm.umn.edu/rsvp](@/rsvp.md)
+
+
+And remember to find us at Open House in the ACM room (Keller 2-204) on Wednesdays from 4-6pm to hang out, chat, study, or whatever else you want to do.
+
+
+Have nice days,
+
+Quinn

--- a/content/newsletter/2025-03-24-newsletter.md
+++ b/content/newsletter/2025-03-24-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 10"
 template = "post.html"
 
-description = ""
+description = "RSVP for the blog workshop and come for free pizza."
 slug = "2025-s-w10"
 
-date = 2024-03-24
+date = 2025-03-24
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-03-24-newsletter.md
+++ b/content/newsletter/2025-03-24-newsletter.md
@@ -1,0 +1,32 @@
++++
+title = "ACM S25 Week 10"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w10"
+
+date = 2024-03-24
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+## Let's do Blog Workshop!
+
+It's this Thursday and we'll guide you thru basic web dev all the way to building your own blog using the Zola framework! Gain skills, express yourself, enjoy free pizza, etc.!
+- March 27 @ 6pm
+- Keller 3-111
+- RSVP for the free pizza → [acm.umn.edu/rsvp](@/rsvp.md)
+
+aaaaaaaannd...
+
+```
+Open House
+ACM room (Keller 2-204)
+Wednesdays 4-6pm
+Hang out, chat, study, anything you want!
+```
+
+Willow wispily,
+
+Quinn

--- a/content/newsletter/2025-04-14-newsletter.md
+++ b/content/newsletter/2025-04-14-newsletter.md
@@ -1,0 +1,41 @@
++++
+title = "ACM S25 Week 13"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w13"
+
+date = 2024-04-14
+
+authors = ["Quinn"]
++++
+Hi ACM,
+
+## CTF is this Thursday!
+
+Learn how to “hack” in a friendly Capture the Flag competition! Vulnerable systems ranging from websites to filesystems will be provided and points will be awarded based on your reverse engineering ability. Beginners welcome, we will provide help!
+- April 17 @ 5:30pm
+- Amundson B75
+- RSVP for the free pizza → acm.umn.edu/rsvp
+
+## Also, get ready for Presentation Night next Wednesday!
+
+Come talk to us about your favorite obscure programming language, tell a really elaborate joke, or anything else you want to present to people about! Or simply watch and enjoy with some free pizza!
+- April 23 @ 5:30pm
+- Keller 3-115
+- RSVP for the free pizza → acm.umn.edu/rsvp
+- Let an ACM officer know in person or on the discord if you'd like to present
+
+and never forget...
+
+```
+Open House
+ACM room (Keller 2-204)
+Wednesdays 4-6pm
+Hang out, chat, study, anything you want!
+```
+
+
+See you soon,
+
+Quinn

--- a/content/newsletter/2025-04-14-newsletter.md
+++ b/content/newsletter/2025-04-14-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 13"
 template = "post.html"
 
-description = ""
+description = "Capture the Flag this Thursday. Presentation night next Wednesday."
 slug = "2025-s-w13"
 
-date = 2024-04-14
+date = 2025-04-14
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-04-22-newsletter.md
+++ b/content/newsletter/2025-04-22-newsletter.md
@@ -1,0 +1,34 @@
++++
+title = "ACM S25 Week 14"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w14"
+
+date = 2024-04-22
+
+authors = ["Quinn"]
++++
+I love ACM!
+
+## Presentation Night is this Wednesday!
+Come talk to us about your favorite obscure programming language, tell a really elaborate joke, or anything else you want to present to people about! Or simply watch and enjoy with some free pizza!
+- April 23 @ 5:30pm
+- Keller 3-115
+- RSVP for the free pizza → [acm.umn.edu/rsvp](@/rsvp.md)
+- Let an ACM officer know in person or on the discord if you'd like to present
+
+And naturally,
+
+```
+Open House
+ACM room (Keller 2-204)
+Wednesdays 4-6pm
+Hang out, chat, study, anything you want!
+```
+
+Really,
+
+Quinn
+
+_Secretary, ACM UMN_

--- a/content/newsletter/2025-04-22-newsletter.md
+++ b/content/newsletter/2025-04-22-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 14"
 template = "post.html"
 
-description = ""
+description = "Let an ACM UMN Officer know if you would like to present for Presentation Night."
 slug = "2025-s-w14"
 
-date = 2024-04-22
+date = 2025-04-22
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-04-29-newsletter.md
+++ b/content/newsletter/2025-04-29-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM S25 Week 15"
 template = "post.html"
 
-description = ""
+description = "Figuring out officers for next year."
 slug = "2025-s-w15"
 
-date = 2024-04-29
+date = 2025-04-29
 
 authors = ["Quinn"]
 +++

--- a/content/newsletter/2025-04-29-newsletter.md
+++ b/content/newsletter/2025-04-29-newsletter.md
@@ -1,0 +1,29 @@
++++
+title = "ACM S25 Week 15"
+template = "post.html"
+
+description = ""
+slug = "2025-s-w15"
+
+date = 2024-04-29
+
+authors = ["Quinn"]
++++
+All the special events are up, it's the final slide of the year, and ACM UMN is figuring out officers for next year.
+
+Current members (have attended 3 events this school year, have paid a $10 fee this academic year, or have paid a $5 fee this semester) may submit their candidacy if they'd like here.
+
+If you need a break from the studying, or a space to change up your rhythm as you work, stop by...
+
+```
+Open House
+ACM room (Keller 2-204)
+Wednesdays 4-6pm
+Hang out, chat, study, anything you want!
+```
+
+By chance,
+
+Quinn
+
+_Secretary, ACM UMN_

--- a/content/newsletter/2025-09-29-newsletter.md
+++ b/content/newsletter/2025-09-29-newsletter.md
@@ -1,0 +1,30 @@
++++
+title = "ACM F25 Week 5"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w5"
+
+date = 2024-09-29
+
+authors = ["Ángel"]
++++
+Welcome to week five, here are events...
+
+
+## Unix Class 2
+Akerman 225, Tuesday 5:30pm
+
+Come to our second Unix class session about git! We will have pizza and merge conflicts.
+
+## Open House
+ACM room (Keller 2-204), Tuesdays 4-6pm
+
+Hang out, chat, study, anything you want!
+
+
+Peace,
+
+Ángel
+
+_V(i)P, ACM UMN_

--- a/content/newsletter/2025-09-29-newsletter.md
+++ b/content/newsletter/2025-09-29-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 5"
 template = "post.html"
 
-description = ""
+description = "Second Unix class is on Git. Have a merge conflict with your pizza."
 slug = "2025-f-w5"
 
-date = 2024-09-29
+date = 2025-09-29
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-10-06-newsletter.md
+++ b/content/newsletter/2025-10-06-newsletter.md
@@ -1,0 +1,32 @@
++++
+title = "ACM F25 Week 6"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w6"
+
+date = 2024-10-06
+
+authors = ["Ángel"]
++++
+Sup gang,
+
+Welcome to week 6. Here are some events,,,
+
+## Unix Class 3
+Akerman 225, Tuesday 5:30pm
+
+Come to our second Unix class session about setting up your programming environment. We'll configure VSCode + Bashrc.
+
+## Open House
+ACM room (Keller 2-204), Tuesdays 4-6pm
+
+Hang out, chat, study, anything you want!
+
+Peace,
+
+
+
+Ángel
+
+_VP, ACM UMN_

--- a/content/newsletter/2025-10-06-newsletter.md
+++ b/content/newsletter/2025-10-06-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 6"
 template = "post.html"
 
-description = ""
+description = "Unix 3 is on programming environments. Come by the ACM Room in Keller 2-204!"
 slug = "2025-f-w6"
 
-date = 2024-10-06
+date = 2025-10-06
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-10-13-newsletter.md
+++ b/content/newsletter/2025-10-13-newsletter.md
@@ -1,0 +1,31 @@
++++
+title = "ACM F25 Week 7"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w7"
+
+date = 2024-10-13
+
+authors = ["Ángel"]
++++
+Gang, get ready for week 7 events...
+
+
+## Unix Class 4 FINALE ❄
+Akerman 225, Tuesday @ 5:30pm
+
+Come to our final Unix class session. We'll learn about nix package management and guaranteed reproducibility in post-unix environments.
+
+## Open House 🛖
+ACM room (Keller 2-204), Tuesdays @ 4-6pm
+
+Hang out, chat, study, be cool, calm, and collected B-)
+
+
+
+Peace,
+
+Ángel
+
+_VP, ACM UMN_

--- a/content/newsletter/2025-10-13-newsletter.md
+++ b/content/newsletter/2025-10-13-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 7"
 template = "post.html"
 
-description = ""
+description = "The end of Unix Class: Post-Unix environments and NixOS."
 slug = "2025-f-w7"
 
-date = 2024-10-13
+date = 2025-10-13
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-10-20-newsletter.md
+++ b/content/newsletter/2025-10-20-newsletter.md
@@ -1,0 +1,34 @@
++++
+title = "ACM F25 Week 8"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w8"
+
+date = 2024-10-20
+
+authors = ["Ángel"]
++++
+Gang, get ready for week 8 events...
+
+RSVP for events here 👉 [rsvp](@/rsvp.md) so we can get more pizza money for our events.
+
+## Self-Hosting Workshop 1 (PIZZA PRESENT) 💪
+Keller 3-230, Tuesday @ 5:30PM
+
+Learn how to host your own website with ACM hardware. VMs locally sourced from our own organic, GMO-free server closet.
+
+🍕s in attendance. Fill out this form for SSH access: https://forms.gle/uPTiKDsu65fxBAT18
+
+## Open House 🛖
+ACM Clubroom (Keller 2-204), Tuesdays @ 4-6PM
+
+Hang out, chat, study, be cool, calm, and collected B-) .
+
+
+
+Peace,
+
+Ángel
+
+_VP, ACM UMN_

--- a/content/newsletter/2025-10-20-newsletter.md
+++ b/content/newsletter/2025-10-20-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 8"
 template = "post.html"
 
-description = ""
+description = "Learn to self host your own organic, GMO-free blog on home-grown ACM hardware!"
 slug = "2025-f-w8"
 
-date = 2024-10-20
+date = 2025-10-20
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-11-10-newsletter.md
+++ b/content/newsletter/2025-11-10-newsletter.md
@@ -1,0 +1,35 @@
++++
+title = "ACM F25 Week 11"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w11"
+
+date = 2024-11-10
+
+authors = ["Ángel"]
++++
+Gang,
+
+Get ready for week 11 events...
+
+RSVP here 👉 [rsvp](@/rsvp.md) so we can get more pizza money for our events.
+
+## Typst Workshop ✍️📜
+Keller 3-115, Thursday 5PM
+
+Learn to render fancy math notation, resumes, or your own gutenberg bible with programmatic typesetting. Learn Typst this Thursday!
+
+PIZZAS IN ATTENDANCE 🍕
+
+## 🚨🚨NO Open House🚨🚨
+Gone fishin' 🐟
+
+We'll be around throughout the week tho. Drop by if you see us chilling at keller 2-204.
+
+
+Peace,
+
+Ángel
+
+_VP, ACM UMN_

--- a/content/newsletter/2025-11-10-newsletter.md
+++ b/content/newsletter/2025-11-10-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 11"
 template = "post.html"
 
-description = ""
+description = "No open house. PIZZA IN ATTENDANCE at the Typst workshop this week."
 slug = "2025-f-w11"
 
-date = 2024-11-10
+date = 2025-11-10
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-11-17-newsletter.md
+++ b/content/newsletter/2025-11-17-newsletter.md
@@ -1,0 +1,42 @@
++++
+title = "ACM F25 Week 12"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w12"
+
+date = 2024-11-17
+
+authors = ["Ángel"]
++++
+Gang,
+
+Get ready for week 12 events,,,
+
+RSVP here 👉 [rsvp](@/rsvp.md) so we can get more pizza money for our events.
+
+
+## Drawing Night 🎨
+ACM Clubroom (Keller 2-204), Tuesday 5PM
+
+De-stress with art and chatting this week. Drawing Night is a time-honored ACM tradition. Bring a friend and leave your mark on our clubroom!
+
+## Open House 🛖
+ACM Clubroom (Keller 2-204), Tuesdays 4-6PM
+
+Hang out, chat, study, be cool, calm, and collected B-) .
+
+## Book Club of Enoch 📜 🌄
+Carlson 2-215, Thursday 4PM
+
+Our friends at UMN BLOG CLUB are doing a Book Club of Enoch this week.
+
+Check out their deats here 👉 [umn.page/book-club.htm](https://umn.page/book-club.htm)
+
+
+
+Peace,
+
+Ángel
+
+_VP, ACM UMN_

--- a/content/newsletter/2025-11-17-newsletter.md
+++ b/content/newsletter/2025-11-17-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 12"
 template = "post.html"
 
-description = ""
+description = "Blog club friends. Drawing Night. Open house."
 slug = "2025-f-w12"
 
-date = 2024-11-17
+date = 2025-11-17
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-12-06-newsletter.md
+++ b/content/newsletter/2025-12-06-newsletter.md
@@ -2,10 +2,10 @@
 title = "ACM F25 Week 15"
 template = "post.html"
 
-description = ""
+description = "Show and Tell your cool knowledge and LaTeX beamer slides at Show and Tell this Thursday."
 slug = "2025-f-w15"
 
-date = 2024-12-06
+date = 2025-12-06
 
 authors = ["Ángel"]
 +++

--- a/content/newsletter/2025-12-06-newsletter.md
+++ b/content/newsletter/2025-12-06-newsletter.md
@@ -1,0 +1,39 @@
++++
+title = "ACM F25 Week 15"
+template = "post.html"
+
+description = ""
+slug = "2025-f-w15"
+
+date = 2024-12-06
+
+authors = ["Ángel"]
++++
+Gang,
+
+This is our FINAL week for ACM 2025. Don't be sad it's over, be happy that it happened.
+
+RSVP here 👉 [rsvp](@/rsvp.md) so we can get more pizza money for our events.
+
+
+## Show and Tell 🛝🍕
+Keller 3-230, Tuesday 5PM
+
+Show off projects, knowledge, LaTeX beamer slides about anything cool to you.
+
+@officers in our discord or e-mail acm@umn.edu if you're interested in presenting.
+
+Pizzas shall be in attendance!
+
+## Open House FINALE 🛖
+ACM Clubroom (Keller 2-204), Tuesdays 4-6PM
+
+Hang out, chat, study, be cool, calm, and collected B-) .
+
+
+
+Enjoy your break,
+
+Ángel
+
+_VP, ACM UMN_

--- a/content/rsvp.md
+++ b/content/rsvp.md
@@ -1,0 +1,5 @@
++++
+title = "link to RSVP for events"
+template = "redirect.html"
+description = "https://docs.google.com/forms/d/e/1FAIpQLSeVhVeeOXxFML1NZvNABlUcQZTf1YcwBouAJ28pE385r8HE7g/viewform"
++++


### PR DESCRIPTION
This ports the ACM UMN newsletter from HTML in Mailchimp to Markdown in the website.

This is a draft PR because not all newsletters have been added yet.