### PR TITLE
Even Navbar Link Spacing

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -10,9 +10,9 @@ $nav-padd-in-out: 8px;
     @include grid-bar;
     @include set-with-screen(
         grid-template-columns,
-        repeat(6, 1fr),
-        repeat(3, 1fr),
-        repeat(1, 1fr)
+        repeat(6, auto),
+        repeat(3, auto),
+        repeat(1, auto)
     );
 
     @include hover-fixed;


### PR DESCRIPTION
This evens the spacing of links on the navigation bar.