### PR TITLE
docs: update git repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It also uses the SCSS flavor of [Sass](https://sass-lang.com/) for styling.
 ### Building
 
 1. Install [Zola](https://www.getzola.org/).
-2. Clone this repo with `git clone git@github.com:acmumn/new-acm-site.git`.
+2. Clone this repo with `git clone git@github.com:acmumn/website.git`.
 3. Run `zola serve` from the root of the project.
 4. The site will be served to `localhost:1111`.
 


### PR DESCRIPTION
PR on main, corrects mention of git clone to the correct repo, this is no longer called new acm site.