### PR TITLE
Navbar Style

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -28,13 +28,14 @@ $nav-padd-in-out: 8px;
         @include headings {
             color: #fff;
             @include light-title;
-            @include set-with-screen(font-size, 1.7em, 1.5em, 1.2em);
+            @include set-with-screen(font-size, 1.4em, 1.5em, 1.2em);
+            text-decoration: none;
         }
         text-decoration: none;
         &:hover {
-            text-decoration: none;
+            color: #ffcc33;
             @include headings {
-                text-decoration: none;
+                color: #ffcc33;
             }
         }
     }

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -20,7 +20,7 @@ $hr-spacing: 25px;
 
 $home-grid-padding: 13px;
 
-$nav-height: 100px;
+$nav-height: 40px;
 $phone-nav-height: 85px;
 
 $home-image-height: 300px;

--- a/static/scripts/toggle-menu.js
+++ b/static/scripts/toggle-menu.js
@@ -11,7 +11,7 @@ function updateNavbar() {
 
     // not on a phone
     if (window.innerWidth > 580) {
-        document.getElementById('navbar').style.height = '100px';
+        document.getElementById('navbar').style.height = 'none';
 
         for (let i = 0; i < children.length; i++) {
             if (i == 0) { continue; }
@@ -20,7 +20,7 @@ function updateNavbar() {
         return;
     }
 
-    document.getElementById('navbar').style.height = 'fit-content';
+    document.getElementById('navbar').style.height = 'none';
 
     if (!isMenuOpen) {
         display = 'none';


### PR DESCRIPTION
Background: see #63 .

This shrinks the navigation menu to fit the size of the links inside it.

This updates the link style of the navigation bar to not have underlines and use Gopher Gold color when hovering.