### PR TITLE
Remove Meeting Minutes from RSS Feed

### DIFF
--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -19,7 +19,8 @@
       <language>{{ lang }}</language>
       <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
       {% if last_updated is defined %}<lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>{% endif %}
-      {%- for page in pages %}
+      {% set section = get_section(path = "newsletter/_index.md" ) %}
+      {%- for page in section.pages | sort(attribute="date") | reverse %}
       <item>
           <title>{{ page.title }}</title>
           <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>


### PR DESCRIPTION
This removes the meeting minutes from the RSS feed, leaving just the newsletter.