### PR TITLE
Fix: Officer Cards Cropped at Certain Resolutions

### DIFF
--- a/sass/contact.scss
+++ b/sass/contact.scss
@@ -2,10 +2,10 @@
 
 .officer-card {
     padding: 0px;
-    height: $officer-card-height;
     border-radius: $std-rounding;
 
     width: 100%;
+    aspect-ratio: 1.1;
 
     justify-self: center;
     justify-content: center;


### PR DESCRIPTION
This fixes officer cards getting cropped at smaller resolutions.

Background: see #62 .