### PR TITLE
Safari

### DIFF
--- a/sass/home.scss
+++ b/sass/home.scss
@@ -119,7 +119,7 @@
         ),
         calc(
             100vh - 300px - 1em - $small-home-image-height - 2 *
-                $small-home-padding - $nav-height
+                $small-home-padding - $mid-nav-height
         ),
         calc(
             100vh - 300px - $phone-home-image-height - 2 * $phone-home-padding -

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -156,7 +156,7 @@ body {
         @include set-with-screen(
             padding-top,
             calc($nav-height + $section-padding),
-            calc($nav-height + $section-padding),
+            calc($mid-nav-height + $section-padding),
             calc($phone-nav-height + $section-padding)
         );
     }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -19,7 +19,6 @@ $nav-padd-in-out: 8px;
     top: 0;
 
     background-color: $accent;
-    height: fit-content;
     padding-top: $nav-padd-in-out;
     padding-bottom: $nav-padd-in-out;
     gap: 0;

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -21,6 +21,7 @@ $hr-spacing: 25px;
 $home-grid-padding: 13px;
 
 $nav-height: 40px;
+$mid-nav-height: 70px;
 $phone-nav-height: 85px;
 
 $home-image-height: 300px;


### PR DESCRIPTION
This fixes the navbar always being full height on Safari.

This fixes the navbar height for mid-sized screens.