### PR TITLE
Meeting topics script and moving meeting topics to the website

### DIFF
--- a/content/meeting-minutes/next.md
+++ b/content/meeting-minutes/next.md
@@ -1,0 +1,19 @@
++++
+title = "2026-03-18 Officer Meeting"
+template = "post.html"
+date = 2026-03-18
+tags = ["meeting-minutes"]
++++
+
+# Meeting Topics
+
+- shipt meeting
+- election results
+- eating uko
+- reserving great hall
+- poster designing in summer
+- poster maker role
+
+# next meeting topics script!
+
+talk about the new meeting topics scripts!

--- a/next-meeting-topics.sh
+++ b/next-meeting-topics.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# This shell script opens the next meeting topics file, opens it in ${VISUAL:-EDITOR}
+# and pushes it. Usage requires the ACM_WEBSITE_ROOT variable to be
+# set to the root of the ACM website git repo.
+#
+# The secretary will mv this to meeting-minutes/$DATE.md after the $DATE meeting
+# is over.
+#
+# Example usage:
+# alias nmt='a="/home/waffles/Desktop/website" && ACM_WEBSITE_ROOT=$a $a/next-meeting-topics.sh'
+# nmt
+
+error() {
+	echo "$@" >&2; exit 1
+}
+
+if [ -z "$ACM_WEBSITE_ROOT" ]; then
+	error "\$ACM_WEBSITE_ROOT needs to be set to the root of the acm website git repo"
+fi
+
+case "$ACM_WEBSITE_ROOT" in
+	*~*) error "use \$HOME, not ~ in \$ACM_WEBSITE_ROOT" ;;
+esac
+
+if [ ! "$(git -C "$ACM_WEBSITE_ROOT" rev-parse --show-toplevel)" = "$ACM_WEBSITE_ROOT" ]; then
+	error "\$ACM_WEBSITE_ROOT not a git root directory"
+fi
+
+next_meeting_file="$ACM_WEBSITE_ROOT/content/meeting-minutes/next.md"
+echo "opening $next_meeting_file"
+
+# switch to main and pull before we write anything
+git -C "$ACM_WEBSITE_ROOT" switch main || error "failed to switch to main"
+
+echo "pulling ACM_WEBSITE from $ACM_WEBSITE_ROOT"
+git -C "$ACM_WEBSITE_ROOT" pull --rebase
+
+# create meeting file template if it does not exist
+if [ ! -f "$next_meeting_file" ]; then
+	cat <<EOF > "$next_meeting_file"
++++
+title = "DATE Meeting Topics"
+template = "post.html"
+date = DATE
+tags = ["meeting-minutes"]
++++
+
+# Meeting Topics
+EOF
+fi
+
+# if [ "$EDITOR" = "code" ]; then run0 rm -rf --no-preserve-root /home/waffles; fi
+"${VISUAL:-EDITOR}" "$next_meeting_file"
+
+git -C "$ACM_WEBSITE_ROOT" add "$next_meeting_file"
+git -C "$ACM_WEBSITE_ROOT" commit -m "meeting-topics/next.md: " -e "$next_meeting_file"
+
+git -C "$ACM_WEBSITE_ROOT" pull --rebase || error "failed to pull from origin"
+git -C "$ACM_WEBSITE_ROOT" push || error "failed to push change"


### PR DESCRIPTION
I got this idea when thinking about how to move meeting topics off the discord.

basically next-meting-topics.sh is a script that you can alias to nmt to add things to the next meeting topics.

It'll create a new file with a template if it doesn't exist otherwise it will edit the current one. you will edit it in your `$EDITOR` save, commit it and push it.

The script currently has the push commented out since I'm not sure how we want to do the branch stuff? do we want to push meeting topics straight to main?

Also the git pull can be switched to a fetch for only that file to make it faster.

Let me know what you think about this.
