### PR TITLE
meeting minutes script: error checks, extra pull, add next

### DIFF
--- a/next-meeting-topics.sh
+++ b/next-meeting-topics.sh
@@ -17,21 +17,47 @@ of the acm website git repo on your machine"
 	exit 1
 fi
 
+if [ "$(echo "$ACM_WEBSITE_ROOT" | cut -c1-1)" = "~" ]; then
+	echo "the ACM_WEBSITE_ROOT environment variable should not include '~' to
+reference the home directory. use \$HOME instead."
+	exit 1
+fi
 
 next_meeting_file="$ACM_WEBSITE_ROOT/content/meeting-minutes/next.md"
 echo "opening $next_meeting_file"
 
 # switch to main and pull before we write anything
-#git -C "$ACM_WEBSITE_ROOT" switch main # commented out to test it out
+git -C "$ACM_WEBSITE_ROOT" switch main
+if [ "$?" -ne 0 ]; then
+	echo "failed to switch to main branch. stash changes or switch to main first.";
+fi
+
 echo "pulling ACM_WEBSITE from $ACM_WEBSITE_ROOT"
-git -C "$ACM_WEBSITE_ROOT" pull
+git -C "$ACM_WEBSITE_ROOT" pull --rebase
+
+# create meeting file template if it does not exist
+if [ ! -f "$next_meeting_file" ]; then
+	echo "+++
+title = \"<yyyy-mm-dd> Officer Meeting\"
+template = \"post.html\"
+date = <yyyy-mm-dd>
+tags = [\"meeting-minutes\"]
++++" > "$next_meeting_file";
+fi
 
 # open the file and edit it.
 $EDITOR "$next_meeting_file"
 
 # add it and commit the change
+git -C "$ACM_WEBSITE_ROOT" add "$next_meeting_file"
 git -C "$ACM_WEBSITE_ROOT" commit -m "meeting-topics/next.md: " -e "$next_meeting_file"
 
+git -C "$ACM_WEBSITE_ROOT" pull --rebase
+if [ "$?" -ne 0 ]; then
+	echo "failed to automatically rebase new commits from remote. please fix conflicts and then 'git -C \"\$ACM_WEBSITE_ROOT\" push'"
+fi
 
 #push the change
-#git -C "$ACM_WEBSITE_ROOT" push
+git -C "$ACM_WEBSITE_ROOT" push && exit 0
+echo "failed to push to git remote '$(git remote get-url origin)'."
+exit 1


### PR DESCRIPTION
this adds checks that the root dir doesn't use '~', that switching to main succeeds, and that the git pull and push succeed.

this uses git --rebase for pulls explicitly.

this adds a template next.md file if none exists.

this adds a few error messages.